### PR TITLE
feat: auto-merge Dependabot PRs for Bounteous package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: "direct"
+    groups:
+      all-nuget:
+        patterns:
+          - "*"
     commit-message:
       prefix: "chore(deps):"
     pull-request-branch-name:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,14 +18,14 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Auto-merge Bounteous package updates
-        if: startsWith(steps.metadata.outputs.dependency-names, 'Bounteous.')
+        if: contains(steps.metadata.outputs.dependency-names, 'Bounteous.')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Auto-approve Bounteous package updates
-        if: startsWith(steps.metadata.outputs.dependency-names, 'Bounteous.')
+        if: contains(steps.metadata.outputs.dependency-names, 'Bounteous.')
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Auto-merge Bounteous Dependabot PRs
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-merge Bounteous package updates
+        if: startsWith(steps.metadata.outputs.dependency-names, 'Bounteous.')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-approve Bounteous package updates
+        if: startsWith(steps.metadata.outputs.dependency-names, 'Bounteous.')
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add Dependabot configuration to group all NuGet updates into a single PR
- Add GitHub Actions workflow that auto-approves and squash-merges grouped Dependabot PRs only when they include a `Bounteous.*` package update
- Third-party-only dependency updates still require manual review
- Auto-merge repo setting has been enabled

## Test plan
- [ ] Verify workflow triggers on next Dependabot PR containing a Bounteous.* update
- [ ] Verify non-Bounteous dependency PRs are not auto-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)